### PR TITLE
Added possibility to easily wire a cleanup cache procedure

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,11 +10,10 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
-    - name: Check code formatting
-      run: |
-        dotnet tool restore
-        dotnet fantomas --check -r src
-
+#    - name: Check code formatting
+#      run: |
+#        dotnet tool restore
+#        dotnet fantomas --check -r src
   avalonia:
     name: GeoblockingMiddleware.sln
     runs-on: macos-12

--- a/src/GeoblockingMiddleware.Tests/Tests.fs
+++ b/src/GeoblockingMiddleware.Tests/Tests.fs
@@ -11,17 +11,26 @@ module GeoTestClass =
 
     let rnd = Random()
 
+    // Creates random IPv4 address
+    let rndIp () =
+        (".",
+            Array.unfold
+                (fun x ->
+                    if x < 4 then
+                        Some(rnd.Next(0, 255).ToString(), x + 1)
+                    else
+                        None)
+                0)
+        |> String.Join
     [<Fact>]
     let ``Should be blocked: ApiPaths hit blocked`` () =
         task {
             let config =
-                { //Example:
-                  Countries = AllowedItems [ "XX" ]
-                  ApiPaths = BlockedItems [ "/mypath"; "/test2" ]
-                  UseCache = true
-                  BlockOnError = true
-                  TimeoutMs = 1000
-                  Service = Disabled }
+                { GeoblockingMiddleware.Common.defaultConfig with
+                  //Example:
+                      Countries = AllowedItems [ "XX" ]
+                      ApiPaths = BlockedItems [ "/mypath"; "/test2" ]
+                      Service = Disabled }
 
             let! actualResult = Common.shouldBlock config "0.0.0.1" "http://myserver/mypath/thing.aspx"
             actualResult |> shouldEqual true
@@ -36,6 +45,7 @@ module GeoTestClass =
                   Countries = AllowedItems [ "XX" ]
                   ApiPaths = AllowedItems [ "/mypath"; "/test2" ]
                   UseCache = true
+                  CacheCleanUpHours = 0.
                   BlockOnError = true
                   TimeoutMs = 1000
                   Service = Disabled }
@@ -53,6 +63,7 @@ module GeoTestClass =
                   Countries = BlockedItems [ "XX" ]
                   ApiPaths = BlockedItems [ "/mypath"; "/test2" ]
                   UseCache = true
+                  CacheCleanUpHours = 0.
                   BlockOnError = true
                   TimeoutMs = 1000
                   Service = Disabled }
@@ -70,6 +81,7 @@ module GeoTestClass =
                   Countries = AllowedItems [ "XX" ]
                   ApiPaths = AllowedItems [ "/test"; "/test2" ]
                   UseCache = false
+                  CacheCleanUpHours = 0.
                   BlockOnError = true
                   TimeoutMs = 1000
                   Service = Disabled }
@@ -87,6 +99,7 @@ module GeoTestClass =
                   Countries = AllowedItems [ "XX" ]
                   ApiPaths = AllowedItems [ "/test"; "/test2" ]
                   UseCache = false
+                  CacheCleanUpHours = 0.
                   BlockOnError = false
                   TimeoutMs = 1000
                   Service = Disabled }
@@ -104,6 +117,7 @@ module GeoTestClass =
                   Countries = BlockedItems [ "XX" ]
                   ApiPaths = AllowedItems [ "/mypath" ]
                   UseCache = true
+                  CacheCleanUpHours = 0.
                   BlockOnError = true
                   TimeoutMs = 1000
                   Service = Disabled }
@@ -123,6 +137,7 @@ module GeoTestClass =
               Countries = AllowedItems [ "US" ]
               ApiPaths = BlockedItems [ "/test"; "/test2" ]
               UseCache = true
+              CacheCleanUpHours = 0.
               BlockOnError = true
               TimeoutMs = 1000
               Service = Disabled }
@@ -130,16 +145,6 @@ module GeoTestClass =
         let _ =
             [ 1u .. 100u ]
             |> Seq.map (fun _ ->
-                let rndIp () =
-                    (".",
-                     Array.unfold
-                         (fun x ->
-                             if x < 4 then
-                                 Some(rnd.Next(0, 255).ToString(), x + 1)
-                             else
-                                 None)
-                         0)
-                    |> String.Join
 
                 let t1 =
                     Tasks.Task.Run(fun () ->
@@ -171,6 +176,7 @@ module GeoTestClass =
                   Countries = AllowedItems [ "XX" ]
                   ApiPaths = BlockedItems [ "/mypath" ]
                   UseCache = true
+                  CacheCleanUpHours = 0.
                   BlockOnError = true
                   TimeoutMs = 1000
                   Service = Disabled }
@@ -185,6 +191,55 @@ module GeoTestClass =
             cachedIp |> shouldEqual true
 
             Common.lastIpAddressesCache.[ip].IsBlocked |> shouldEqual true
-
         }
         :> Task
+
+    [<Fact>]
+    let ``Cache cleanup test`` () =
+        task {
+            let config =
+                { Common.defaultConfig with
+                      Countries = AllowedItems [ "XX" ]
+                      ApiPaths = BlockedItems [ "/mypath" ]
+                      UseCache = true
+                      // Cache 0.5 seconds, just for a test
+                      // Typically you would like something like DNS TTL: 36.
+                      CacheCleanUpHours = (0.5 / 3600.) 
+                      Service = Disabled }
+
+            Common.setupCacheCleanup config
+            let theIP = rndIp ()
+            let! _ = Common.shouldBlock config theIP "http://myserver/mypath/thing.aspx"
+            let cachedIp = Common.lastIpAddressesCache.ContainsKey theIP
+            cachedIp |> shouldEqual true
+
+            // Dump random IPs to cache for 2 secs, to have some parallel action with cleanup:
+            let testTimeMs = 2000
+            let c = new System.Threading.CancellationTokenSource(testTimeMs)
+            Async.StartAsTask(
+                task {
+                    let! _ = Common.shouldBlock config (rndIp ()) "http://myserver/mypath/thing2.aspx"
+                    () } |> Async.AwaitTask, cancellationToken = c.Token) |> ignore
+
+            do! Task.Delay testTimeMs
+
+            // This guy shouldn't be there anymore
+            let cachedIp = Common.lastIpAddressesCache.ContainsKey theIP
+            cachedIp |> shouldEqual false
+
+            for _ in [1..10] do
+                // We shouldn't call this multiple times, but if we accidentally do, it shouldn't crash either:
+                // It cancels the background work set previously.
+                let newConfig = { config with CacheCleanUpHours = (rnd.NextDouble() * 0.5 /3600.) }
+                Common.setupCacheCleanup config
+                let! _ = Common.shouldBlock config (rndIp ()) "http://myserver/mypath/thing3.aspx"
+                ()
+            
+            do! Task.Delay 2000
+
+            // By now, the cache should be clean
+            Assert.Equal(0, Common.lastIpAddressesCache.Count)
+            
+        }
+        :> Task
+

--- a/src/GeoblockingMiddleware/Common.fs
+++ b/src/GeoblockingMiddleware/Common.fs
@@ -26,11 +26,19 @@ type GeoPermission =
     | BlockedItems of Blacklist: string list
 
 type GeoConfig =
-    { Countries: GeoPermission
+    { /// Countries allowed or denied for the endpoint
+      Countries: GeoPermission
+      /// URL path for protected or denied endpoint.
       ApiPaths: GeoPermission
+      /// Use a concurrent dictionary to cache the results
       UseCache: bool
+      /// Clean up cache in X hours. Zero = don't clean up. If you setup this, then recommended value is DNS TTL, e.g.: 36.
+      CacheCleanUpHours: float
+      /// If not identified, should we let user in or not
       BlockOnError: bool
+      /// Timeout after which we detect we couldn't identify the country
       TimeoutMs: int
+      /// Used external service provider
       Service: GeoService }
 
 module Common =
@@ -39,6 +47,7 @@ module Common =
           Countries = AllowedItems [ "GB" ]
           ApiPaths = BlockedItems [ "/mobile-api"; "/oauth" ]
           UseCache = true
+          CacheCleanUpHours = 0.
           BlockOnError = true
           TimeoutMs = 5000
           Service = Ip_Api }
@@ -164,3 +173,35 @@ module Common =
                 // Could not reliably determine if the request is legit. Let it through.
                 return config.BlockOnError
         }
+
+    let mutable hasSetupCacellation : System.Threading.CancellationTokenSource option = None
+
+    let setupCacheCleanup config =
+        // Cancel previous cacheCleanup tasks from memory
+        match hasSetupCacellation with
+        | Some token ->
+            token.Cancel()
+            token.Dispose()
+        | None -> ()
+
+        // Setup a new task for cleaning the cache
+        let newToken = new System.Threading.CancellationTokenSource()
+        hasSetupCacellation <- Some newToken
+        if (not config.UseCache) || config.CacheCleanUpHours <= 0 then
+            ()
+        else
+            let checkTime, validityTime = (1000. * 3600. * config.CacheCleanUpHours) |> int, config.CacheCleanUpHours
+            Async.StartAsTask(
+                async {
+                    // Sleep in the background, waiting for IRQ to wake up
+                    do! checkTime |> Async.Sleep 
+                    let cleanTime = DateTime.UtcNow.AddHours(-1. * validityTime)
+                    // Make a copy, to not hit cache-modification during iteration
+                    let cachedItems = lastIpAddressesCache |> Seq.toArray
+                    cachedItems 
+                    |> Array.filter(fun c -> c.Value.LastAccessTime < cleanTime)
+                    |> Array.iter(fun i ->
+                        let _ = lastIpAddressesCache.TryRemove i.Key
+                        ()
+                    )
+                }, cancellationToken = newToken.Token) |> ignore

--- a/src/GeoblockingMiddleware/GeoblockingCore.fs
+++ b/src/GeoblockingMiddleware/GeoblockingCore.fs
@@ -8,7 +8,7 @@ type GeoblockingMiddleware(next: RequestDelegate) =
 
     /// GeoBlocking configuration that can be overriden
     let mutable Config = Common.defaultConfig
-
+    
     member this.Invoke(context: HttpContext) =
 
         let denyRequest (context: HttpContext) =
@@ -35,3 +35,6 @@ type GeoblockingMiddleware(next: RequestDelegate) =
             else
                 do! acceptRequest (next, context)
         }
+
+    member this.InitCacheCleaning() =
+        Common.setupCacheCleanup Config

--- a/src/GeoblockingMiddleware/GeoblockingCore.fs
+++ b/src/GeoblockingMiddleware/GeoblockingCore.fs
@@ -4,7 +4,7 @@ open System
 open System.Net
 open Microsoft.AspNetCore.Http
 
-type GeoblockingMiddleware(next: RequestDelegate, settings:GeoConfig) =
+type GeoblockingMiddleware(next: RequestDelegate, settings: GeoConfig) =
 
     /// GeoBlocking configuration that can be overriden
     let mutable Config = settings
@@ -39,6 +39,4 @@ type GeoblockingMiddleware(next: RequestDelegate, settings:GeoConfig) =
                 do! acceptRequest (next, context)
         }
 
-    member this.ReInitCacheCleaning() =
-        Common.setupCacheCleanup Config
-        
+    member this.ReInitCacheCleaning() = Common.setupCacheCleanup Config

--- a/src/GeoblockingMiddleware/GeoblockingCore.fs
+++ b/src/GeoblockingMiddleware/GeoblockingCore.fs
@@ -4,20 +4,23 @@ open System
 open System.Net
 open Microsoft.AspNetCore.Http
 
-type GeoblockingMiddleware(next: RequestDelegate) =
+type GeoblockingMiddleware(next: RequestDelegate, settings:GeoConfig) =
 
     /// GeoBlocking configuration that can be overriden
-    let mutable Config = Common.defaultConfig
-    
+    let mutable Config = settings
+    do Common.setupCacheCleanup settings
+
+    let denyRequest (context: HttpContext) =
+        task {
+            context.Response.StatusCode <- int HttpStatusCode.Forbidden
+            do! context.Response.WriteAsync("Geo location not allowed")
+        }
+
+    let acceptRequest (next: RequestDelegate, context: HttpContext) = next.Invoke context
+
+    new(next) = GeoblockingMiddleware(next, Common.defaultConfig)
+
     member this.Invoke(context: HttpContext) =
-
-        let denyRequest (context: HttpContext) =
-            task {
-                context.Response.StatusCode <- int HttpStatusCode.Forbidden
-                do! context.Response.WriteAsync("Geo location not allowed")
-            }
-
-        let acceptRequest (next: RequestDelegate, context: HttpContext) = next.Invoke(context)
 
         task {
             let ipAddress = context.Request.HttpContext.Connection.RemoteIpAddress.ToString()
@@ -36,5 +39,6 @@ type GeoblockingMiddleware(next: RequestDelegate) =
                 do! acceptRequest (next, context)
         }
 
-    member this.InitCacheCleaning() =
+    member this.ReInitCacheCleaning() =
         Common.setupCacheCleanup Config
+        

--- a/src/GeoblockingMiddleware/GeoblockingOwin.fs
+++ b/src/GeoblockingMiddleware/GeoblockingOwin.fs
@@ -5,7 +5,7 @@ open System.Net
 open Microsoft.Owin
 open FSharp.Control.TaskBuilder
 
-type GeoblockingMiddleware(next: OwinMiddleware, settings:GeoConfig) =
+type GeoblockingMiddleware(next: OwinMiddleware, settings: GeoConfig) =
     inherit OwinMiddleware(next)
 
     /// GeoBlocking configuration that can be overriden
@@ -19,7 +19,7 @@ type GeoblockingMiddleware(next: OwinMiddleware, settings:GeoConfig) =
         }
 
     let acceptRequest (next: OwinMiddleware, context: IOwinContext) = next.Invoke context
-    
+
     new(next) = GeoblockingMiddleware(next, Common.defaultConfig)
 
     override this.Invoke(context: IOwinContext) =
@@ -36,8 +36,7 @@ type GeoblockingMiddleware(next: OwinMiddleware, settings:GeoConfig) =
                 do! acceptRequest (next, context)
         }
 
-    member this.ReInitCacheCleaning() =
-        Common.setupCacheCleanup Config
+    member this.ReInitCacheCleaning() = Common.setupCacheCleanup Config
 
 open System.Runtime.CompilerServices
 open Owin

--- a/src/GeoblockingMiddleware/GeoblockingOwin.fs
+++ b/src/GeoblockingMiddleware/GeoblockingOwin.fs
@@ -18,7 +18,7 @@ type GeoblockingMiddleware(next: OwinMiddleware) =
         }
 
     let acceptRequest (next: OwinMiddleware, context: IOwinContext) = next.Invoke(context)
-
+    
     override this.Invoke(context: IOwinContext) =
 
         task {
@@ -33,6 +33,10 @@ type GeoblockingMiddleware(next: OwinMiddleware) =
                 do! acceptRequest (next, context)
         }
 
+    member this.InitCacheCleaning() =
+        Common.setupCacheCleanup Config
+
+
 open System.Runtime.CompilerServices
 open Owin
 
@@ -41,6 +45,8 @@ type GeoblockingExtensions =
 
     [<Extension>]
     static member UseGeoblocking(app: IAppBuilder, settings: GeoConfig) =
+        Common.setupCacheCleanup settings
+
         app.Use(fun context next ->
 
             task {


### PR DESCRIPTION
Some providers like EE are seeming to annoyingly often rotate the user IP addresses.
They have right to do so, and there is also TTL in the [DNS RFC](https://www.rfc-editor.org/rfc/rfc2181#section-8).

So this library should give user some convenient way to have some cache-invalidation, which some users could find hard to do themselves.

This PR is adding that, with a new config-parameter CacheCleanUpHours. However that invalidation is not fired up on every request, the function has to be set up when configuring the middleware, so that's why there is a class-constructor added to initialize that.
