### PR TITLE
Added HttpClientFactory to reuse HttpClient

### DIFF
--- a/src/GeoblockingMiddleware/GeoblockingMiddleware.fsproj
+++ b/src/GeoblockingMiddleware/GeoblockingMiddleware.fsproj
@@ -55,5 +55,9 @@
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
PR to address the issue described in #3.

Creating a new HttpClient every time may result in socket exhaustion. However, keeping the same HttpClient application wide doesn't respect DNS changes in long-running applications (https://github.com/dotnet/runtime/issues/18348).

Using [HttpClientFactory](https://github.com/aspnet/HttpClientFactory) seems to me like the best approach.

 